### PR TITLE
Fix bugs associated with virtual MFA and listing of log groups

### DIFF
--- a/iam_group.tf
+++ b/iam_group.tf
@@ -32,10 +32,34 @@ data "aws_iam_policy_document" "bod_lambda_log_doc" {
   }
 }
 
-# The CloudWatch log policy for our IAM group
+# IAM policy document that allows listing of CloudWatch log groups.
+# This will be applied to the IAM group we are creating.
+data "aws_iam_policy_document" "list_log_doc" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:DescribeLogGroups",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+# The CloudWatch log policy for our IAM group that lets the users view
+# the BOD 18-01 Lambda logs.
 resource "aws_iam_group_policy" "bod_log_watchers" {
   count = "${length(var.scan_types)}"
 
   group  = "${aws_iam_group.bod_log_watchers.id}"
   policy = "${data.aws_iam_policy_document.bod_lambda_log_doc.*.json[count.index]}"
+}
+
+# The CloudWatch log policy for our IAM group that lets the users list
+# the CloudWatch log groups associated with the account.
+resource "aws_iam_group_policy" "list_logs" {
+  group  = "${aws_iam_group.bod_log_watchers.id}"
+  policy = "${data.aws_iam_policy_document.list_log_doc.json}"
 }

--- a/iam_users.tf
+++ b/iam_users.tf
@@ -24,6 +24,7 @@ resource "aws_iam_user_group_membership" "user" {
 data "aws_iam_policy_document" "iam_self_admin_doc" {
   count = "${length(var.usernames)}"
 
+  # Allow users to view their own account information
   statement {
     effect = "Allow"
 
@@ -128,7 +129,9 @@ data "aws_iam_policy_document" "iam_self_admin_doc" {
     ]
 
     resources = [
-      "${aws_iam_user.user.*.arn[count.index]}",
+      # The MFA ARN is identical to that of the user, except that the
+      # text "user" is replaced by "mfa"
+      "${replace(aws_iam_user.user.*.arn[count.index], "user", "mfa")}",
     ]
   }
 


### PR DESCRIPTION
When testing with the account I set up for @bjb28, we found that he was unable to create a virtual MFA device or view the list of all log groups.  This pull request fixes those issues.

Note that it is secure to allow the user to view all log groups, since he or she can only view the BOD 18-01 Lambda logs.  It just makes getting to those logs via the console considerably more convenient.