### PR TITLE
Allow users to change their PW before setting up MFA

### DIFF
--- a/iam_users.tf
+++ b/iam_users.tf
@@ -156,6 +156,7 @@ data "aws_iam_policy_document" "iam_self_admin_doc" {
     effect = "Deny"
 
     not_actions = [
+      "iam:ChangePassword",
       "iam:CreateVirtualMFADevice",
       "iam:EnableMFADevice",
       "iam:GetUser",


### PR DESCRIPTION
The console makes them change their PW before setting up MFA, and there is no way to do that without adding this permission to the "non-MFA" permissions.