### PR TITLE
Allow filtering on log streams

### DIFF
--- a/bodlambdalogreadaccess_policy.tf
+++ b/bodlambdalogreadaccess_policy.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "bodlambdalogreadaccess_policy_doc" {
       "logs:GetLogEvents",
     ]
     effect    = "Allow"
-    resources = [for k, v in data.aws_cloudwatch_log_group.bod_lambda_logs : v.arn]
+    resources = flatten([for k, v in data.aws_cloudwatch_log_group.bod_lambda_logs : [v.arn, "${v.arn}:log-stream:"]])
   }
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request alters the Terraform code to allow the `logs:FilterLogEvents` action on both:
- The log group ARNs
- The log group ARNs appended with `:log-stream:`

## 💭 Motivation and context ##

User @jeffkause is unable to filter on log events in the `/aws/lambda/task_pshtt` log group without this change.  Resolves #26.

## 🧪 Testing ##

All automated tests pass.  I have already applied this change to our CyHy environment and @jeffkause verified that it fixed the issue he was having.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.